### PR TITLE
Update createError to use AxiosError

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,9 +9,9 @@ var _axios = require('axios');
 
 var _axios2 = _interopRequireDefault(_axios);
 
-var _createError = require('axios/lib/core/createError');
+var _AxiosError = require('axios/lib/core/AxiosError');
 
-var _createError2 = _interopRequireDefault(_createError);
+var _AxiosError2 = _interopRequireDefault(_AxiosError);
 
 var _objectPathImmutable = require('object-path-immutable');
 
@@ -40,7 +40,7 @@ var apiRequest = exports.apiRequest = function apiRequest(url) {
     }
 
     if (hasValidContentType(res) === false) {
-      throw (0, _createError2.default)('Invalid Content-Type in response', res.config, null, res);
+      throw (0, _AxiosError2.default)('Invalid Content-Type in response', null, res.config, res);
     }
 
     return res.data;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import createError from 'axios/lib/core/createError';
+import createError from 'axios/lib/core/AxiosError';
 import imm from 'object-path-immutable';
 
 export const jsonContentTypes = [
@@ -29,8 +29,8 @@ export const apiRequest = (url, options = {}) => {
       if (hasValidContentType(res) === false) {
         throw createError(
           'Invalid Content-Type in response',
-          res.config,
           null,
+          res.config,
           res
         );
       }


### PR DESCRIPTION
This updates the use to errors in Axios since createError has been updated to AxiosError and the arg position updated too
Ref: [New](https://github.com/axios/axios/blob/v0.30.0/lib/core/AxiosError.js), [Old](https://github.com/axios/axios/blob/v0.26.0/lib/core/createError.js)
@abdulsemiu-atanda @JohnnySantiagoJr Please help review